### PR TITLE
feat: Store health challenge as user goal

### DIFF
--- a/lib/api/goals.ts
+++ b/lib/api/goals.ts
@@ -1,12 +1,21 @@
 import { createSelectSchema } from 'drizzle-zod';
-import type { z } from 'zod';
+import { z } from 'zod';
 import { userGoal } from '@/lib/db/schema';
 
 // Types derived from schema
 const selectSchema = createSelectSchema(userGoal);
 export type GoalResponse = z.infer<typeof selectSchema>;
 
+// Create goal request schema
+export const createGoalSchema = z.object({
+  title: z.string().min(1).max(200),
+  description: z.string().optional(),
+});
+
+export type CreateGoalRequest = z.infer<typeof createGoalSchema>;
+
 // API contract
 export type GoalsApi = {
   GET: { response: GoalResponse[] };
+  POST: { request: CreateGoalRequest; response: GoalResponse };
 };


### PR DESCRIPTION
Why: Health challenge data collected in onboarding step 4 was being discarded instead of saved. Users couldn't track or reference their primary health challenge.

What:
- Added POST endpoint to goals API for creating new goals
- Added createGoalSchema for request validation
- Added useCreateGoal hook for creating goals from frontend
- Updated onboarding to create a goal from healthChallenge field
- Goal is created with title 'Primary Health Challenge' and user's description
- Fixed onboarding merge conflict code (removed duplicate declarations)
- Fixed router path to use correct tabs route

Technical details:
- Health challenge becomes an active goal visible to health consultant agent
- Goal can be tracked, updated, or marked complete over time
- Leverages existing goals system instead of adding static profile field
- Goal creation happens after profile upsert succeeds