### PR TITLE
feat: Add TimePicker component for profile time inputs

### DIFF
--- a/app/(app)/(profile)/eating.tsx
+++ b/app/(app)/(profile)/eating.tsx
@@ -5,6 +5,7 @@ import { Controller, useForm } from 'react-hook-form';
 import { ScrollView } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { z } from 'zod';
+import { TimePicker } from '@/components/TimePicker';
 import { Button, Input, Spinner, Text, XStack, YStack } from '@/components/ui';
 import { useProfile, useUpsertProfile } from '@/lib/hooks/use-profile';
 
@@ -154,30 +155,26 @@ export default function EatingScheduleScreen() {
           </YStack>
 
           {/* Typical Meal Times */}
-          <YStack gap="$2">
-            <Text fontSize="$4" fontWeight="600">
-              Typical Meal Times
-            </Text>
-            <Text fontSize="$2" color="gray">
-              When do you usually eat?
-            </Text>
+          <YStack gap="$3">
+            <YStack gap="$1">
+              <Text fontSize="$4" fontWeight="600">
+                Typical Meal Times
+              </Text>
+              <Text fontSize="$2" color="gray">
+                When do you usually eat?
+              </Text>
+            </YStack>
             {mealTimes.map((_time, index) => (
               <Controller
                 key={`meal-time-${index}-${_time}`}
                 control={control}
                 name={`typicalMealTimes.${index}`}
                 render={({ field: { onChange, value } }) => (
-                  <XStack gap="$2" alignItems="center">
-                    <Text fontSize="$3" minWidth={60}>
-                      Meal {index + 1}:
-                    </Text>
-                    <Input
-                      flex={1}
-                      value={value}
-                      onChangeText={onChange}
-                      placeholder="08:00"
-                    />
-                  </XStack>
+                  <TimePicker
+                    label={`Meal ${index + 1}`}
+                    value={value}
+                    onChange={onChange}
+                  />
                 )}
               />
             ))}

--- a/app/(app)/(profile)/eating.tsx
+++ b/app/(app)/(profile)/eating.tsx
@@ -1,3 +1,11 @@
+/**
+ * Eating Schedule Screen
+ *
+ * Allows users to input their eating habits including meals per day,
+ * typical meal times, snacking habits, and water intake. This information
+ * is used to provide personalized nutrition and energy recommendations.
+ */
+
 import { zodResolver } from '@hookform/resolvers/zod';
 import { router } from 'expo-router';
 import { useState } from 'react';
@@ -46,10 +54,7 @@ export default function EatingScheduleScreen() {
     },
   });
 
-  // Using direct array management instead of useFieldArray for now
   const mealTimes = watch('typicalMealTimes') || [];
-
-  const _waterIntake = watch('waterIntakeLiters');
 
   // Adjust meal times array when meals per day changes
   const handleMealsChange = (value: number) => {

--- a/app/(app)/(profile)/sleep.tsx
+++ b/app/(app)/(profile)/sleep.tsx
@@ -5,6 +5,7 @@ import { Controller, useForm } from 'react-hook-form';
 import { ScrollView } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { z } from 'zod';
+import { TimePicker } from '@/components/TimePicker';
 import { Button, Input, Spinner, Text, XStack, YStack } from '@/components/ui';
 import { useProfile, useUpsertProfile } from '@/lib/hooks/use-profile';
 
@@ -171,56 +172,32 @@ export default function SleepPatternsScreen() {
           </YStack>
 
           {/* Typical Wake Time */}
-          <YStack gap="$2">
-            <Text fontSize="$4" fontWeight="600">
-              Typical Wake Time
-            </Text>
-            <Controller
-              control={control}
-              name="typicalWakeTime"
-              render={({ field: { onChange, value } }) => (
-                <Input
-                  value={value}
-                  onChangeText={onChange}
-                  placeholder="07:00"
-                />
-              )}
-            />
-            <Text fontSize="$2" color="gray">
-              Format: HH:MM (24-hour)
-            </Text>
-            {errors.typicalWakeTime && (
-              <Text color="red" fontSize="$2">
-                {errors.typicalWakeTime.message}
-              </Text>
+          <Controller
+            control={control}
+            name="typicalWakeTime"
+            render={({ field: { onChange, value } }) => (
+              <TimePicker
+                label="Typical Wake Time"
+                value={value}
+                onChange={onChange}
+                error={errors.typicalWakeTime?.message}
+              />
             )}
-          </YStack>
+          />
 
           {/* Typical Bed Time */}
-          <YStack gap="$2">
-            <Text fontSize="$4" fontWeight="600">
-              Typical Bed Time
-            </Text>
-            <Controller
-              control={control}
-              name="typicalBedTime"
-              render={({ field: { onChange, value } }) => (
-                <Input
-                  value={value}
-                  onChangeText={onChange}
-                  placeholder="23:00"
-                />
-              )}
-            />
-            <Text fontSize="$2" color="gray">
-              Format: HH:MM (24-hour)
-            </Text>
-            {errors.typicalBedTime && (
-              <Text color="red" fontSize="$2">
-                {errors.typicalBedTime.message}
-              </Text>
+          <Controller
+            control={control}
+            name="typicalBedTime"
+            render={({ field: { onChange, value } }) => (
+              <TimePicker
+                label="Typical Bed Time"
+                value={value}
+                onChange={onChange}
+                error={errors.typicalBedTime?.message}
+              />
             )}
-          </YStack>
+          />
         </YStack>
       </YStack>
     </ScrollView>

--- a/app/(app)/(profile)/sleep.tsx
+++ b/app/(app)/(profile)/sleep.tsx
@@ -44,7 +44,6 @@ export default function SleepPatternsScreen() {
   const {
     control,
     handleSubmit,
-    watch,
     formState: { errors },
   } = useForm<FormData>({
     resolver: zodResolver(formSchema),
@@ -57,9 +56,6 @@ export default function SleepPatternsScreen() {
       typicalBedTime: profile?.typicalBedTime || '23:00',
     },
   });
-
-  const _sleepHours = watch('sleepHoursAverage');
-  const _sleepQuality = watch('sleepQuality');
 
   const onSubmit = async (data: FormData) => {
     setIsSaving(true);

--- a/components/TimePicker.tsx
+++ b/components/TimePicker.tsx
@@ -1,0 +1,139 @@
+import { useState } from 'react';
+import { Button, Input, Text, XStack, YStack } from '@/components/ui';
+
+interface TimePickerProps {
+  value: string;
+  onChange: (time: string) => void;
+  label?: string;
+  error?: string;
+}
+
+export function TimePicker({ value, onChange, label, error }: TimePickerProps) {
+  const [hours, setHours] = useState(() => {
+    const [h] = value.split(':');
+    return h || '07';
+  });
+  const [minutes, setMinutes] = useState(() => {
+    const [, m] = value.split(':');
+    return m || '00';
+  });
+
+  const handleHoursChange = (text: string) => {
+    const num = parseInt(text, 10);
+    if (text === '' || (num >= 0 && num <= 23)) {
+      const formatted = text === '' ? '' : text.padStart(2, '0');
+      setHours(formatted);
+      if (formatted && minutes) {
+        onChange(`${formatted}:${minutes}`);
+      }
+    }
+  };
+
+  const handleMinutesChange = (text: string) => {
+    const num = parseInt(text, 10);
+    if (text === '' || (num >= 0 && num <= 59)) {
+      const formatted = text === '' ? '' : text.padStart(2, '0');
+      setMinutes(formatted);
+      if (hours && formatted) {
+        onChange(`${hours}:${formatted}`);
+      }
+    }
+  };
+
+  const incrementHours = () => {
+    const newHours = ((parseInt(hours || '0', 10) + 1) % 24)
+      .toString()
+      .padStart(2, '0');
+    setHours(newHours);
+    onChange(`${newHours}:${minutes}`);
+  };
+
+  const decrementHours = () => {
+    const newHours = ((parseInt(hours || '0', 10) - 1 + 24) % 24)
+      .toString()
+      .padStart(2, '0');
+    setHours(newHours);
+    onChange(`${newHours}:${minutes}`);
+  };
+
+  const incrementMinutes = () => {
+    const newMinutes = ((parseInt(minutes || '0', 10) + 15) % 60)
+      .toString()
+      .padStart(2, '0');
+    setMinutes(newMinutes);
+    onChange(`${hours}:${newMinutes}`);
+  };
+
+  const decrementMinutes = () => {
+    const newMinutes = ((parseInt(minutes || '0', 10) - 15 + 60) % 60)
+      .toString()
+      .padStart(2, '0');
+    setMinutes(newMinutes);
+    onChange(`${hours}:${newMinutes}`);
+  };
+
+  return (
+    <YStack gap="$2">
+      {label && (
+        <Text fontSize="$4" fontWeight="600">
+          {label}
+        </Text>
+      )}
+      <XStack gap="$3" alignItems="center" flexWrap="wrap">
+        <YStack gap="$2" alignItems="center" minWidth={80}>
+          <Button size="$2" onPress={incrementHours} width={70}>
+            ▲
+          </Button>
+          <Input
+            value={hours}
+            onChangeText={handleHoursChange}
+            keyboardType="number-pad"
+            maxLength={2}
+            textAlign="center"
+            width={70}
+            paddingHorizontal="$2"
+          />
+          <Button size="$2" onPress={decrementHours} width={70}>
+            ▼
+          </Button>
+        </YStack>
+
+        <Text fontSize="$8" fontWeight="bold" paddingHorizontal="$2">
+          :
+        </Text>
+
+        <YStack gap="$2" alignItems="center" minWidth={80}>
+          <Button size="$2" onPress={incrementMinutes} width={70}>
+            ▲
+          </Button>
+          <Input
+            value={minutes}
+            onChangeText={handleMinutesChange}
+            keyboardType="number-pad"
+            maxLength={2}
+            textAlign="center"
+            width={70}
+            paddingHorizontal="$2"
+          />
+          <Button size="$2" onPress={decrementMinutes} width={70}>
+            ▼
+          </Button>
+        </YStack>
+
+        <YStack gap="$1" marginLeft="$2">
+          <Text fontSize="$2" color="gray">
+            24-hour
+          </Text>
+          <Text fontSize="$2" color="gray">
+            format
+          </Text>
+        </YStack>
+      </XStack>
+      {error && (
+        <Text color="red" fontSize="$2">
+          {error}
+        </Text>
+      )}
+    </YStack>
+  );
+}

--- a/components/TimePicker.tsx
+++ b/components/TimePicker.tsx
@@ -84,15 +84,17 @@ export function TimePicker({ value, onChange, label, error }: TimePickerProps) {
           <Button size="$2" onPress={incrementHours} width={70}>
             ▲
           </Button>
-          <Input
-            value={hours}
-            onChangeText={handleHoursChange}
-            keyboardType="number-pad"
-            maxLength={2}
-            textAlign="center"
-            width={70}
-            paddingHorizontal="$2"
-          />
+          <YStack width={70} alignItems="center">
+            <Input
+              value={hours}
+              onChangeText={handleHoursChange}
+              keyboardType="number-pad"
+              maxLength={2}
+              textAlign="center"
+              width={70}
+              paddingHorizontal="$2"
+            />
+          </YStack>
           <Button size="$2" onPress={decrementHours} width={70}>
             ▼
           </Button>
@@ -106,15 +108,17 @@ export function TimePicker({ value, onChange, label, error }: TimePickerProps) {
           <Button size="$2" onPress={incrementMinutes} width={70}>
             ▲
           </Button>
-          <Input
-            value={minutes}
-            onChangeText={handleMinutesChange}
-            keyboardType="number-pad"
-            maxLength={2}
-            textAlign="center"
-            width={70}
-            paddingHorizontal="$2"
-          />
+          <YStack width={70} alignItems="center">
+            <Input
+              value={minutes}
+              onChangeText={handleMinutesChange}
+              keyboardType="number-pad"
+              maxLength={2}
+              textAlign="center"
+              width={70}
+              paddingHorizontal="$2"
+            />
+          </YStack>
           <Button size="$2" onPress={decrementMinutes} width={70}>
             ▼
           </Button>

--- a/components/TimePicker.tsx
+++ b/components/TimePicker.tsx
@@ -1,26 +1,42 @@
+/**
+ * TimePicker Component
+ *
+ * A user-friendly time picker with 12-hour AM/PM format.
+ * Features increment/decrement buttons and direct keyboard input.
+ * Internally converts to 24-hour format for backend storage.
+ */
+
 import { useState } from 'react';
 import { Button, Input, Text, XStack, YStack } from '@/components/ui';
 
 interface TimePickerProps {
-  value: string;
-  onChange: (time: string) => void;
+  value: string; // 24-hour format (HH:MM)
+  onChange: (time: string) => void; // Returns 24-hour format (HH:MM)
   label?: string;
   error?: string;
 }
 
-function convert24To12Hour(hour24: number): { hour12: number; period: 'AM' | 'PM' } {
+/**
+ * Convert 24-hour time to 12-hour format with AM/PM
+ */
+function convert24To12Hour(hour24: number): {
+  hour12: number;
+  period: 'AM' | 'PM';
+} {
   if (hour24 === 0) return { hour12: 12, period: 'AM' };
   if (hour24 < 12) return { hour12: hour24, period: 'AM' };
   if (hour24 === 12) return { hour12: 12, period: 'PM' };
   return { hour12: hour24 - 12, period: 'PM' };
 }
 
+/**
+ * Convert 12-hour time with AM/PM to 24-hour format
+ */
 function convert12To24Hour(hour12: number, period: 'AM' | 'PM'): number {
   if (period === 'AM') {
     return hour12 === 12 ? 0 : hour12;
-  } else {
-    return hour12 === 12 ? 12 : hour12 + 12;
   }
+  return hour12 === 12 ? 12 : hour12 + 12;
 }
 
 export function TimePicker({ value, onChange, label, error }: TimePickerProps) {


### PR DESCRIPTION
## Summary
- Add TimePicker component with 12-hour AM/PM format and increment/decrement controls
- Replace text inputs with TimePicker in sleep and eating profile screens

## Test plan
- [ ] Verify time picker displays and saves correctly
- [ ] Test AM/PM toggle and increment/decrement buttons

🤖 Generated with [Claude Code](https://claude.com/claude-code)